### PR TITLE
TLS/SSL support

### DIFF
--- a/php/5.6/apache/Dockerfile
+++ b/php/5.6/apache/Dockerfile
@@ -32,6 +32,6 @@ COPY docker-php-entrypoint /usr/local/bin/
 WORKDIR /var/www/app
 
 # Enable SSL
-RUN a2enmod ssl
+RUN a2enmod ssl rewrite headers
 RUN a2ensite default-ssl
 EXPOSE 443

--- a/php/5.6/apache/Dockerfile
+++ b/php/5.6/apache/Dockerfile
@@ -33,5 +33,4 @@ WORKDIR /var/www/app
 
 # Enable SSL
 RUN a2enmod ssl rewrite headers
-RUN a2ensite default-ssl
 EXPOSE 443

--- a/php/5.6/apache/Dockerfile
+++ b/php/5.6/apache/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get upgrade -y \
         libpq-dev \
         libzip-dev zlib1g-dev \
         libpcre3-dev \
+        ssl-cert \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include \
@@ -29,3 +30,8 @@ COPY docker-php-entrypoint /usr/local/bin/
 
 # workdir
 WORKDIR /var/www/app
+
+# Enable SSL
+RUN a2enmod ssl
+RUN a2ensite default-ssl
+EXPOSE 443

--- a/php/7.1/apache/Dockerfile
+++ b/php/7.1/apache/Dockerfile
@@ -30,6 +30,6 @@ COPY docker-php-entrypoint /usr/local/bin/
 WORKDIR /var/www/app
 
 # Enable SSL
-RUN a2enmod ssl
+RUN a2enmod ssl rewrite headers
 RUN a2ensite default-ssl
 EXPOSE 443

--- a/php/7.1/apache/Dockerfile
+++ b/php/7.1/apache/Dockerfile
@@ -31,5 +31,4 @@ WORKDIR /var/www/app
 
 # Enable SSL
 RUN a2enmod ssl rewrite headers
-RUN a2ensite default-ssl
 EXPOSE 443

--- a/php/7.1/apache/Dockerfile
+++ b/php/7.1/apache/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get upgrade -y \
         libpq-dev \
         libzip-dev zlib1g-dev \
         libpcre3-dev \
+        ssl-cert \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include \
@@ -27,3 +28,8 @@ COPY docker-php-entrypoint /usr/local/bin/
 
 # workdir
 WORKDIR /var/www/app
+
+# Enable SSL
+RUN a2enmod ssl
+RUN a2ensite default-ssl
+EXPOSE 443

--- a/php/7.2/apache/Dockerfile
+++ b/php/7.2/apache/Dockerfile
@@ -30,6 +30,6 @@ COPY docker-php-entrypoint /usr/local/bin/
 WORKDIR /var/www/app
 
 # Enable SSL
-RUN a2enmod ssl
+RUN a2enmod ssl rewrite headers
 RUN a2ensite default-ssl
 EXPOSE 443

--- a/php/7.2/apache/Dockerfile
+++ b/php/7.2/apache/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
         libpq-dev \
         libzip-dev zlib1g-dev \
         libpcre3-dev \
+        ssl-cert \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include \
@@ -27,3 +28,8 @@ COPY docker-php-entrypoint /usr/local/bin/
 
 # workdir
 WORKDIR /var/www/app
+
+# Enable SSL
+RUN a2enmod ssl
+RUN a2ensite default-ssl
+EXPOSE 443

--- a/php/7.2/apache/Dockerfile
+++ b/php/7.2/apache/Dockerfile
@@ -31,5 +31,4 @@ WORKDIR /var/www/app
 
 # Enable SSL
 RUN a2enmod ssl rewrite headers
-RUN a2ensite default-ssl
 EXPOSE 443

--- a/php/7.3/apache/Dockerfile
+++ b/php/7.3/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-apache
+FROM php:7.3-apache
 
 # ext-gd: libfreetype6-dev libjpeg62-turbo-dev libpng-dev
 # ext-pgsql: libpq-dev

--- a/php/7.3/apache/Dockerfile
+++ b/php/7.3/apache/Dockerfile
@@ -30,6 +30,6 @@ COPY docker-php-entrypoint /usr/local/bin/
 WORKDIR /var/www/app
 
 # Enable SSL
-RUN a2enmod ssl
+RUN a2enmod ssl rewrite headers
 RUN a2ensite default-ssl
 EXPOSE 443

--- a/php/7.3/apache/Dockerfile
+++ b/php/7.3/apache/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
         libpq-dev \
         libzip-dev zlib1g-dev \
         libpcre3-dev \
+        ssl-cert \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include \
@@ -27,3 +28,8 @@ COPY docker-php-entrypoint /usr/local/bin/
 
 # workdir
 WORKDIR /var/www/app
+
+# Enable SSL
+RUN a2enmod ssl
+RUN a2ensite default-ssl
+EXPOSE 443

--- a/php/7.3/apache/Dockerfile
+++ b/php/7.3/apache/Dockerfile
@@ -31,5 +31,4 @@ WORKDIR /var/www/app
 
 # Enable SSL
 RUN a2enmod ssl rewrite headers
-RUN a2ensite default-ssl
 EXPOSE 443

--- a/php/7.4/apache/Dockerfile
+++ b/php/7.4/apache/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
         libpq-dev \
         libzip-dev zlib1g-dev \
         libpcre3-dev \
+        ssl-cert \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
@@ -27,3 +28,8 @@ COPY docker-php-entrypoint /usr/local/bin/
 
 # workdir
 WORKDIR /var/www/app
+
+# Enable SSL
+RUN a2enmod ssl
+RUN a2ensite default-ssl
+EXPOSE 443

--- a/php/7.4/apache/Dockerfile
+++ b/php/7.4/apache/Dockerfile
@@ -30,6 +30,6 @@ COPY docker-php-entrypoint /usr/local/bin/
 WORKDIR /var/www/app
 
 # Enable SSL
-RUN a2enmod ssl
+RUN a2enmod ssl rewrite headers
 RUN a2ensite default-ssl
 EXPOSE 443

--- a/php/7.4/apache/Dockerfile
+++ b/php/7.4/apache/Dockerfile
@@ -31,5 +31,4 @@ WORKDIR /var/www/app
 
 # Enable SSL
 RUN a2enmod ssl rewrite headers
-RUN a2ensite default-ssl
 EXPOSE 443


### PR DESCRIPTION
close #1 
- Apache の TLS/SSL を有効にする
- PHP7.3のイメージが7.2になっていたため修正
- 利用頻度の高い mod_rewrite, mod_headers モジュールを有効にする