### PR TITLE
Fix php-fpm to apache2-foreground

### DIFF
--- a/php/5.6/apache/docker-php-entrypoint
+++ b/php/5.6/apache/docker-php-entrypoint
@@ -65,7 +65,7 @@ fi
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then
-    set -- php-fpm "$@"
+    set -- apache2-foreground "$@"
 fi
 
 exec "$@"

--- a/php/7.1/apache/docker-php-entrypoint
+++ b/php/7.1/apache/docker-php-entrypoint
@@ -65,7 +65,7 @@ fi
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then
-    set -- php-fpm "$@"
+    set -- apache2-foreground "$@"
 fi
 
 exec "$@"

--- a/php/7.2/apache/docker-php-entrypoint
+++ b/php/7.2/apache/docker-php-entrypoint
@@ -65,7 +65,7 @@ fi
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then
-    set -- php-fpm "$@"
+    set -- apache2-foreground "$@"
 fi
 
 exec "$@"

--- a/php/7.3/apache/docker-php-entrypoint
+++ b/php/7.3/apache/docker-php-entrypoint
@@ -65,7 +65,7 @@ fi
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then
-    set -- php-fpm "$@"
+    set -- apache2-foreground "$@"
 fi
 
 exec "$@"

--- a/php/7.4/apache/docker-php-entrypoint
+++ b/php/7.4/apache/docker-php-entrypoint
@@ -65,7 +65,7 @@ fi
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then
-    set -- php-fpm "$@"
+    set -- apache2-foreground "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
apache のイメージは `apache2-foreground` が正しそうです
https://github.com/docker-library/php/blob/master/7.4/buster/apache/docker-php-entrypoint#L6