### PR TITLE
PHP5.4-5.5 のイメージを追加

### DIFF
--- a/php/5.4/apache/Dockerfile
+++ b/php/5.4/apache/Dockerfile
@@ -1,0 +1,36 @@
+FROM php:5.4-apache
+
+# ext-gd: libfreetype6-dev libjpeg62-turbo-dev libpng-dev
+# ext-mcrypt: libmcrypt-dev
+# ext-pgsql: libpq-dev
+# ext-zip: libzip-dev zlib1g-dev
+# ext-opcache: libpcre3-dev
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y \
+        git unzip curl apt-transport-https gnupg wget \
+        libfreetype6-dev libjpeg62-turbo-dev libpng-dev \
+        libmcrypt-dev \
+        libpq-dev \
+        libzip-dev zlib1g-dev \
+        libpcre3-dev \
+        ssl-cert \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include \
+    && docker-php-ext-install gd mcrypt zip mysql mysqli pgsql
+RUN pecl install apcu-4.0.11 && docker-php-ext-enable apcu
+
+# composer
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+    && php composer-setup.php --install-dir=/usr/local/bin --filename=composer \
+    && php -r "unlink('composer-setup.php');"
+
+# entrypoint
+COPY docker-php-entrypoint /usr/local/bin/
+
+# workdir
+WORKDIR /var/www/app
+
+# Enable SSL
+RUN a2enmod ssl rewrite headers
+EXPOSE 443

--- a/php/5.4/apache/docker-php-entrypoint
+++ b/php/5.4/apache/docker-php-entrypoint
@@ -1,0 +1,71 @@
+#!/bin/sh
+set -e
+
+BASE="/var/www/app"
+
+rm -f /usr/local/etc/php/conf.d/docker.ini
+
+# php config
+if [ -n "${TZ}" ]; then
+    echo "date.timezone = ${TZ}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_MEMORY_LIMIT}" ]; then
+    echo "memory_limit = ${PHP_MEMORY_LIMIT}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+PHP_DISPLAY_ERRORS=${PHP_DISPLAY_ERRORS:-Off}
+if [ -n "${PHP_DISPLAY_ERRORS}" ]; then
+    echo "display_errors = ${PHP_DISPLAY_ERRORS}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_MAX_INPUT_VARS}" ]; then
+    echo "max_input_vars = ${PHP_MAX_INPUT_VARS}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+PHP_EXPOSE_PHP=${PHP_EXPOSE_PHP:-Off}
+if [ -n "${PHP_EXPOSE_PHP}" ]; then
+    echo "expose_php = ${PHP_EXPOSE_PHP}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_MAX_EXECUTION_TIME}" ]; then
+    echo "max_execution_time = ${PHP_MAX_EXECUTION_TIME}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_POST_MAX_SIZE}" ]; then
+    echo "post_max_size = ${PHP_POST_MAX_SIZE}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_UPLOAD_MAX_FILESIZE}" ]; then
+    echo "upload_max_filesize = ${PHP_UPLOAD_MAX_FILESIZE}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+
+# Configure OPcache for Maximum Performance
+if [ -n "${PHP_OPCACHE_MEMORY_CONSUMPTION}" ]; then
+    echo "opcache.memory_consumption = ${PHP_OPCACHE_MEMORY_CONSUMPTION}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+if [ -n "${PHP_OPCACHE_MAX_ACCELERATED_FILES}" ]; then
+    echo "opcache.max_accelerated_files = ${PHP_OPCACHE_MAX_ACCELERATED_FILES}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+# Don't Check PHP Files Timestamps
+if [ -n "${PHP_OPCACHE_VALIDATE_TIMESTAMPS}" ]; then
+    echo "opcache.validate_timestamps = ${PHP_OPCACHE_VALIDATE_TIMESTAMPS}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+# Configure the PHP realpath Cache
+if [ -n "${PHP_REALPATH_CACHE_SIZE}" ]; then
+    echo "realpath_cache_size = ${PHP_REALPATH_CACHE_SIZE}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+if [ -n "${PHP_REALPATH_CACHE_TTL}" ]; then
+    echo "realpath_cache_ttl = ${PHP_REALPATH_CACHE_TTL}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+    set -- apache2-foreground "$@"
+fi
+
+exec "$@"

--- a/php/5.4/cli/Dockerfile
+++ b/php/5.4/cli/Dockerfile
@@ -1,0 +1,34 @@
+FROM php:5.4-cli
+
+# ext-gd: libfreetype6-dev libjpeg62-turbo-dev libpng-dev
+# ext-mcrypt: libmcrypt-dev
+# ext-pgsql: libpq-dev
+# ext-zip: libzip-dev zlib1g-dev
+# ext-opcache: libpcre3-dev
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y \
+        git unzip curl apt-transport-https gnupg wget \
+        libfreetype6-dev libjpeg62-turbo-dev libpng-dev \
+        libmcrypt-dev \
+        libpq-dev \
+        libzip-dev zlib1g-dev \
+        libpcre3-dev \
+        ssl-cert \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include \
+    && docker-php-ext-install gd mcrypt zip mysql mysqli pgsql
+RUN pecl install apcu-4.0.11 && docker-php-ext-enable apcu
+
+# composer
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+    && php composer-setup.php --install-dir=/usr/local/bin --filename=composer \
+    && php -r "unlink('composer-setup.php');"
+
+# entrypoint
+COPY docker-php-entrypoint /usr/local/bin/
+
+# workdir
+WORKDIR /var/www/app
+
+

--- a/php/5.4/cli/docker-php-entrypoint
+++ b/php/5.4/cli/docker-php-entrypoint
@@ -1,0 +1,71 @@
+#!/bin/sh
+set -e
+
+BASE="/var/www/app"
+
+rm -f /usr/local/etc/php/conf.d/docker.ini
+
+# php config
+if [ -n "${TZ}" ]; then
+    echo "date.timezone = ${TZ}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_MEMORY_LIMIT}" ]; then
+    echo "memory_limit = ${PHP_MEMORY_LIMIT}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+PHP_DISPLAY_ERRORS=${PHP_DISPLAY_ERRORS:-Off}
+if [ -n "${PHP_DISPLAY_ERRORS}" ]; then
+    echo "display_errors = ${PHP_DISPLAY_ERRORS}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_MAX_INPUT_VARS}" ]; then
+    echo "max_input_vars = ${PHP_MAX_INPUT_VARS}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+PHP_EXPOSE_PHP=${PHP_EXPOSE_PHP:-Off}
+if [ -n "${PHP_EXPOSE_PHP}" ]; then
+    echo "expose_php = ${PHP_EXPOSE_PHP}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_MAX_EXECUTION_TIME}" ]; then
+    echo "max_execution_time = ${PHP_MAX_EXECUTION_TIME}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_POST_MAX_SIZE}" ]; then
+    echo "post_max_size = ${PHP_POST_MAX_SIZE}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_UPLOAD_MAX_FILESIZE}" ]; then
+    echo "upload_max_filesize = ${PHP_UPLOAD_MAX_FILESIZE}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+
+# Configure OPcache for Maximum Performance
+if [ -n "${PHP_OPCACHE_MEMORY_CONSUMPTION}" ]; then
+    echo "opcache.memory_consumption = ${PHP_OPCACHE_MEMORY_CONSUMPTION}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+if [ -n "${PHP_OPCACHE_MAX_ACCELERATED_FILES}" ]; then
+    echo "opcache.max_accelerated_files = ${PHP_OPCACHE_MAX_ACCELERATED_FILES}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+# Don't Check PHP Files Timestamps
+if [ -n "${PHP_OPCACHE_VALIDATE_TIMESTAMPS}" ]; then
+    echo "opcache.validate_timestamps = ${PHP_OPCACHE_VALIDATE_TIMESTAMPS}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+# Configure the PHP realpath Cache
+if [ -n "${PHP_REALPATH_CACHE_SIZE}" ]; then
+    echo "realpath_cache_size = ${PHP_REALPATH_CACHE_SIZE}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+if [ -n "${PHP_REALPATH_CACHE_TTL}" ]; then
+    echo "realpath_cache_ttl = ${PHP_REALPATH_CACHE_TTL}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+    set -- php "$@"
+fi
+
+exec "$@"

--- a/php/5.4/fpm/Dockerfile
+++ b/php/5.4/fpm/Dockerfile
@@ -1,0 +1,31 @@
+FROM php:5.4-fpm
+
+# ext-gd: libfreetype6-dev libjpeg62-turbo-dev libpng-dev
+# ext-mcrypt: libmcrypt-dev
+# ext-pgsql: libpq-dev
+# ext-zip: libzip-dev zlib1g-dev
+# ext-opcache: libpcre3-dev
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y \
+        git unzip curl apt-transport-https gnupg wget \
+        libfreetype6-dev libjpeg62-turbo-dev libpng-dev \
+        libmcrypt-dev \
+        libpq-dev \
+        libzip-dev zlib1g-dev \
+        libpcre3-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include \
+    && docker-php-ext-install gd mcrypt zip mysql mysqli pgsql
+RUN pecl install apcu-4.0.11 && docker-php-ext-enable apcu
+
+# composer
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+    && php composer-setup.php --install-dir=/usr/local/bin --filename=composer \
+    && php -r "unlink('composer-setup.php');"
+
+# entrypoint
+COPY docker-php-entrypoint /usr/local/bin/
+
+# workdir
+WORKDIR /var/www/app

--- a/php/5.4/fpm/docker-php-entrypoint
+++ b/php/5.4/fpm/docker-php-entrypoint
@@ -1,0 +1,108 @@
+#!/bin/sh
+set -e
+
+BASE="/var/www/app"
+
+DIST="/usr/local/etc/php-fpm.d/www.conf.dist"
+ORIG="/usr/local/etc/php-fpm.d/www.conf"
+if [ ! -e $DIST ]; then
+  cp -f $ORIG $DIST
+else
+  cp -f $DIST $ORIG
+fi
+rm -f /usr/local/etc/php/conf.d/docker.ini
+
+# php config
+if [ -n "${TZ}" ]; then
+    echo "date.timezone = ${TZ}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_MEMORY_LIMIT}" ]; then
+    echo "memory_limit = ${PHP_MEMORY_LIMIT}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+PHP_DISPLAY_ERRORS=${PHP_DISPLAY_ERRORS:-Off}
+if [ -n "${PHP_DISPLAY_ERRORS}" ]; then
+    echo "display_errors = ${PHP_DISPLAY_ERRORS}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_MAX_INPUT_VARS}" ]; then
+    echo "max_input_vars = ${PHP_MAX_INPUT_VARS}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+PHP_EXPOSE_PHP=${PHP_EXPOSE_PHP:-Off}
+if [ -n "${PHP_EXPOSE_PHP}" ]; then
+    echo "expose_php = ${PHP_EXPOSE_PHP}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_MAX_EXECUTION_TIME}" ]; then
+    echo "max_execution_time = ${PHP_MAX_EXECUTION_TIME}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_POST_MAX_SIZE}" ]; then
+    echo "post_max_size = ${PHP_POST_MAX_SIZE}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_UPLOAD_MAX_FILESIZE}" ]; then
+    echo "upload_max_filesize = ${PHP_UPLOAD_MAX_FILESIZE}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+
+# Configure OPcache for Maximum Performance
+if [ -n "${PHP_OPCACHE_MEMORY_CONSUMPTION}" ]; then
+    echo "opcache.memory_consumption = ${PHP_OPCACHE_MEMORY_CONSUMPTION}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+if [ -n "${PHP_OPCACHE_MAX_ACCELERATED_FILES}" ]; then
+    echo "opcache.max_accelerated_files = ${PHP_OPCACHE_MAX_ACCELERATED_FILES}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+# Don't Check PHP Files Timestamps
+if [ -n "${PHP_OPCACHE_VALIDATE_TIMESTAMPS}" ]; then
+    echo "opcache.validate_timestamps = ${PHP_OPCACHE_VALIDATE_TIMESTAMPS}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+# Configure the PHP realpath Cache
+if [ -n "${PHP_REALPATH_CACHE_SIZE}" ]; then
+    echo "realpath_cache_size = ${PHP_REALPATH_CACHE_SIZE}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+if [ -n "${PHP_REALPATH_CACHE_TTL}" ]; then
+    echo "realpath_cache_ttl = ${PHP_REALPATH_CACHE_TTL}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+
+# php-fpm config
+if [ -n "${PHPFPM_PM_MAX_CHILDREN}" ]; then
+    sed -i -e "s|^pm\.max_children = 5|pm.max_children = ${PHPFPM_PM_MAX_CHILDREN}|" /usr/local/etc/php-fpm.d/www.conf
+fi
+
+if [ -n "${PHPFPM_PM_START_SERVERS}" ]; then
+    sed -i -e "s|^pm\.start_servers = 2|pm.start_servers = ${PHPFPM_PM_START_SERVERS}|" /usr/local/etc/php-fpm.d/www.conf
+fi
+
+if [ -n "${PHPFPM_PM_MIN_SPARE_SERVERS}" ]; then
+    sed -i -e "s|^pm\.min_spare_servers = 1|pm.min_spare_servers = ${PHPFPM_PM_MIN_SPARE_SERVERS}|" /usr/local/etc/php-fpm.d/www.conf
+fi
+
+if [ -n "${PHPFPM_PM_MAX_SPARE_SERVERS}" ]; then
+    sed -i -e "s|^pm\.max_spare_servers = 3|pm.max_spare_servers = ${PHPFPM_PM_MAX_SPARE_SERVERS}|" /usr/local/etc/php-fpm.d/www.conf
+fi
+
+if [ -n "${PHPFPM_PM_STATUS_PATH}" ]; then
+    sed -i -e "s|^;pm.status_path = /status|pm.status_path = ${PHPFPM_PM_STATUS_PATH}|" /usr/local/etc/php-fpm.d/www.conf
+fi
+
+if [ -n "${PHPFPM_PING_PATH}" ]; then
+    sed -i -e "s|^;ping.path = /ping|ping.path = ${PHPFPM_PING_PATH}|" /usr/local/etc/php-fpm.d/www.conf
+fi
+
+if [ -n "${PHPFPM_REQUEST_TERMINATE_TIMEOUT}" ]; then
+    sed -i -e "s|^;request_terminate_timeout = 0|request_terminate_timeout = ${PHPFPM_REQUEST_TERMINATE_TIMEOUT}|" /usr/local/etc/php-fpm.d/www.conf
+fi
+
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+    set -- php-fpm "$@"
+fi
+
+exec "$@"

--- a/php/5.5/apache/Dockerfile
+++ b/php/5.5/apache/Dockerfile
@@ -1,0 +1,36 @@
+FROM php:5.5-apache
+
+# ext-gd: libfreetype6-dev libjpeg62-turbo-dev libpng-dev
+# ext-mcrypt: libmcrypt-dev
+# ext-pgsql: libpq-dev
+# ext-zip: libzip-dev zlib1g-dev
+# ext-opcache: libpcre3-dev
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y \
+        git unzip curl apt-transport-https gnupg wget \
+        libfreetype6-dev libjpeg62-turbo-dev libpng-dev \
+        libmcrypt-dev \
+        libpq-dev \
+        libzip-dev zlib1g-dev \
+        libpcre3-dev \
+        ssl-cert \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include \
+    && docker-php-ext-install -j$(nproc) gd mcrypt zip mysql mysqli pgsql opcache
+RUN pecl install apcu-4.0.11 && docker-php-ext-enable apcu
+
+# composer
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+    && php composer-setup.php --install-dir=/usr/local/bin --filename=composer \
+    && php -r "unlink('composer-setup.php');"
+
+# entrypoint
+COPY docker-php-entrypoint /usr/local/bin/
+
+# workdir
+WORKDIR /var/www/app
+
+# Enable SSL
+RUN a2enmod ssl rewrite headers
+EXPOSE 443

--- a/php/5.5/apache/docker-php-entrypoint
+++ b/php/5.5/apache/docker-php-entrypoint
@@ -1,0 +1,71 @@
+#!/bin/sh
+set -e
+
+BASE="/var/www/app"
+
+rm -f /usr/local/etc/php/conf.d/docker.ini
+
+# php config
+if [ -n "${TZ}" ]; then
+    echo "date.timezone = ${TZ}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_MEMORY_LIMIT}" ]; then
+    echo "memory_limit = ${PHP_MEMORY_LIMIT}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+PHP_DISPLAY_ERRORS=${PHP_DISPLAY_ERRORS:-Off}
+if [ -n "${PHP_DISPLAY_ERRORS}" ]; then
+    echo "display_errors = ${PHP_DISPLAY_ERRORS}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_MAX_INPUT_VARS}" ]; then
+    echo "max_input_vars = ${PHP_MAX_INPUT_VARS}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+PHP_EXPOSE_PHP=${PHP_EXPOSE_PHP:-Off}
+if [ -n "${PHP_EXPOSE_PHP}" ]; then
+    echo "expose_php = ${PHP_EXPOSE_PHP}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_MAX_EXECUTION_TIME}" ]; then
+    echo "max_execution_time = ${PHP_MAX_EXECUTION_TIME}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_POST_MAX_SIZE}" ]; then
+    echo "post_max_size = ${PHP_POST_MAX_SIZE}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_UPLOAD_MAX_FILESIZE}" ]; then
+    echo "upload_max_filesize = ${PHP_UPLOAD_MAX_FILESIZE}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+
+# Configure OPcache for Maximum Performance
+if [ -n "${PHP_OPCACHE_MEMORY_CONSUMPTION}" ]; then
+    echo "opcache.memory_consumption = ${PHP_OPCACHE_MEMORY_CONSUMPTION}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+if [ -n "${PHP_OPCACHE_MAX_ACCELERATED_FILES}" ]; then
+    echo "opcache.max_accelerated_files = ${PHP_OPCACHE_MAX_ACCELERATED_FILES}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+# Don't Check PHP Files Timestamps
+if [ -n "${PHP_OPCACHE_VALIDATE_TIMESTAMPS}" ]; then
+    echo "opcache.validate_timestamps = ${PHP_OPCACHE_VALIDATE_TIMESTAMPS}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+# Configure the PHP realpath Cache
+if [ -n "${PHP_REALPATH_CACHE_SIZE}" ]; then
+    echo "realpath_cache_size = ${PHP_REALPATH_CACHE_SIZE}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+if [ -n "${PHP_REALPATH_CACHE_TTL}" ]; then
+    echo "realpath_cache_ttl = ${PHP_REALPATH_CACHE_TTL}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+    set -- apache2-foreground "$@"
+fi
+
+exec "$@"

--- a/php/5.5/cli/Dockerfile
+++ b/php/5.5/cli/Dockerfile
@@ -1,0 +1,34 @@
+FROM php:5.5-cli
+
+# ext-gd: libfreetype6-dev libjpeg62-turbo-dev libpng-dev
+# ext-mcrypt: libmcrypt-dev
+# ext-pgsql: libpq-dev
+# ext-zip: libzip-dev zlib1g-dev
+# ext-opcache: libpcre3-dev
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y \
+        git unzip curl apt-transport-https gnupg wget \
+        libfreetype6-dev libjpeg62-turbo-dev libpng-dev \
+        libmcrypt-dev \
+        libpq-dev \
+        libzip-dev zlib1g-dev \
+        libpcre3-dev \
+        ssl-cert \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include \
+    && docker-php-ext-install -j$(nproc) gd mcrypt zip mysql mysqli pgsql opcache
+RUN pecl install apcu-4.0.11 && docker-php-ext-enable apcu
+
+# composer
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+    && php composer-setup.php --install-dir=/usr/local/bin --filename=composer \
+    && php -r "unlink('composer-setup.php');"
+
+# entrypoint
+COPY docker-php-entrypoint /usr/local/bin/
+
+# workdir
+WORKDIR /var/www/app
+
+

--- a/php/5.5/cli/docker-php-entrypoint
+++ b/php/5.5/cli/docker-php-entrypoint
@@ -1,0 +1,71 @@
+#!/bin/sh
+set -e
+
+BASE="/var/www/app"
+
+rm -f /usr/local/etc/php/conf.d/docker.ini
+
+# php config
+if [ -n "${TZ}" ]; then
+    echo "date.timezone = ${TZ}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_MEMORY_LIMIT}" ]; then
+    echo "memory_limit = ${PHP_MEMORY_LIMIT}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+PHP_DISPLAY_ERRORS=${PHP_DISPLAY_ERRORS:-Off}
+if [ -n "${PHP_DISPLAY_ERRORS}" ]; then
+    echo "display_errors = ${PHP_DISPLAY_ERRORS}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_MAX_INPUT_VARS}" ]; then
+    echo "max_input_vars = ${PHP_MAX_INPUT_VARS}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+PHP_EXPOSE_PHP=${PHP_EXPOSE_PHP:-Off}
+if [ -n "${PHP_EXPOSE_PHP}" ]; then
+    echo "expose_php = ${PHP_EXPOSE_PHP}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_MAX_EXECUTION_TIME}" ]; then
+    echo "max_execution_time = ${PHP_MAX_EXECUTION_TIME}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_POST_MAX_SIZE}" ]; then
+    echo "post_max_size = ${PHP_POST_MAX_SIZE}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_UPLOAD_MAX_FILESIZE}" ]; then
+    echo "upload_max_filesize = ${PHP_UPLOAD_MAX_FILESIZE}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+
+# Configure OPcache for Maximum Performance
+if [ -n "${PHP_OPCACHE_MEMORY_CONSUMPTION}" ]; then
+    echo "opcache.memory_consumption = ${PHP_OPCACHE_MEMORY_CONSUMPTION}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+if [ -n "${PHP_OPCACHE_MAX_ACCELERATED_FILES}" ]; then
+    echo "opcache.max_accelerated_files = ${PHP_OPCACHE_MAX_ACCELERATED_FILES}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+# Don't Check PHP Files Timestamps
+if [ -n "${PHP_OPCACHE_VALIDATE_TIMESTAMPS}" ]; then
+    echo "opcache.validate_timestamps = ${PHP_OPCACHE_VALIDATE_TIMESTAMPS}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+# Configure the PHP realpath Cache
+if [ -n "${PHP_REALPATH_CACHE_SIZE}" ]; then
+    echo "realpath_cache_size = ${PHP_REALPATH_CACHE_SIZE}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+if [ -n "${PHP_REALPATH_CACHE_TTL}" ]; then
+    echo "realpath_cache_ttl = ${PHP_REALPATH_CACHE_TTL}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+    set -- php "$@"
+fi
+
+exec "$@"

--- a/php/5.5/fpm/Dockerfile
+++ b/php/5.5/fpm/Dockerfile
@@ -1,0 +1,31 @@
+FROM php:5.5-fpm
+
+# ext-gd: libfreetype6-dev libjpeg62-turbo-dev libpng-dev
+# ext-mcrypt: libmcrypt-dev
+# ext-pgsql: libpq-dev
+# ext-zip: libzip-dev zlib1g-dev
+# ext-opcache: libpcre3-dev
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y \
+        git unzip curl apt-transport-https gnupg wget \
+        libfreetype6-dev libjpeg62-turbo-dev libpng-dev \
+        libmcrypt-dev \
+        libpq-dev \
+        libzip-dev zlib1g-dev \
+        libpcre3-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include \
+    && docker-php-ext-install -j$(nproc) gd mcrypt zip mysql mysqli pgsql opcache
+RUN pecl install apcu-4.0.11 && docker-php-ext-enable apcu
+
+# composer
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+    && php composer-setup.php --install-dir=/usr/local/bin --filename=composer \
+    && php -r "unlink('composer-setup.php');"
+
+# entrypoint
+COPY docker-php-entrypoint /usr/local/bin/
+
+# workdir
+WORKDIR /var/www/app

--- a/php/5.5/fpm/docker-php-entrypoint
+++ b/php/5.5/fpm/docker-php-entrypoint
@@ -1,0 +1,108 @@
+#!/bin/sh
+set -e
+
+BASE="/var/www/app"
+
+DIST="/usr/local/etc/php-fpm.d/www.conf.dist"
+ORIG="/usr/local/etc/php-fpm.d/www.conf"
+if [ ! -e $DIST ]; then
+  cp -f $ORIG $DIST
+else
+  cp -f $DIST $ORIG
+fi
+rm -f /usr/local/etc/php/conf.d/docker.ini
+
+# php config
+if [ -n "${TZ}" ]; then
+    echo "date.timezone = ${TZ}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_MEMORY_LIMIT}" ]; then
+    echo "memory_limit = ${PHP_MEMORY_LIMIT}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+PHP_DISPLAY_ERRORS=${PHP_DISPLAY_ERRORS:-Off}
+if [ -n "${PHP_DISPLAY_ERRORS}" ]; then
+    echo "display_errors = ${PHP_DISPLAY_ERRORS}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_MAX_INPUT_VARS}" ]; then
+    echo "max_input_vars = ${PHP_MAX_INPUT_VARS}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+PHP_EXPOSE_PHP=${PHP_EXPOSE_PHP:-Off}
+if [ -n "${PHP_EXPOSE_PHP}" ]; then
+    echo "expose_php = ${PHP_EXPOSE_PHP}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_MAX_EXECUTION_TIME}" ]; then
+    echo "max_execution_time = ${PHP_MAX_EXECUTION_TIME}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_POST_MAX_SIZE}" ]; then
+    echo "post_max_size = ${PHP_POST_MAX_SIZE}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+if [ -n "${PHP_UPLOAD_MAX_FILESIZE}" ]; then
+    echo "upload_max_filesize = ${PHP_UPLOAD_MAX_FILESIZE}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+
+# Configure OPcache for Maximum Performance
+if [ -n "${PHP_OPCACHE_MEMORY_CONSUMPTION}" ]; then
+    echo "opcache.memory_consumption = ${PHP_OPCACHE_MEMORY_CONSUMPTION}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+if [ -n "${PHP_OPCACHE_MAX_ACCELERATED_FILES}" ]; then
+    echo "opcache.max_accelerated_files = ${PHP_OPCACHE_MAX_ACCELERATED_FILES}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+# Don't Check PHP Files Timestamps
+if [ -n "${PHP_OPCACHE_VALIDATE_TIMESTAMPS}" ]; then
+    echo "opcache.validate_timestamps = ${PHP_OPCACHE_VALIDATE_TIMESTAMPS}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+# Configure the PHP realpath Cache
+if [ -n "${PHP_REALPATH_CACHE_SIZE}" ]; then
+    echo "realpath_cache_size = ${PHP_REALPATH_CACHE_SIZE}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+if [ -n "${PHP_REALPATH_CACHE_TTL}" ]; then
+    echo "realpath_cache_ttl = ${PHP_REALPATH_CACHE_TTL}" >> /usr/local/etc/php/conf.d/docker.ini
+fi
+
+
+# php-fpm config
+if [ -n "${PHPFPM_PM_MAX_CHILDREN}" ]; then
+    sed -i -e "s|^pm\.max_children = 5|pm.max_children = ${PHPFPM_PM_MAX_CHILDREN}|" /usr/local/etc/php-fpm.d/www.conf
+fi
+
+if [ -n "${PHPFPM_PM_START_SERVERS}" ]; then
+    sed -i -e "s|^pm\.start_servers = 2|pm.start_servers = ${PHPFPM_PM_START_SERVERS}|" /usr/local/etc/php-fpm.d/www.conf
+fi
+
+if [ -n "${PHPFPM_PM_MIN_SPARE_SERVERS}" ]; then
+    sed -i -e "s|^pm\.min_spare_servers = 1|pm.min_spare_servers = ${PHPFPM_PM_MIN_SPARE_SERVERS}|" /usr/local/etc/php-fpm.d/www.conf
+fi
+
+if [ -n "${PHPFPM_PM_MAX_SPARE_SERVERS}" ]; then
+    sed -i -e "s|^pm\.max_spare_servers = 3|pm.max_spare_servers = ${PHPFPM_PM_MAX_SPARE_SERVERS}|" /usr/local/etc/php-fpm.d/www.conf
+fi
+
+if [ -n "${PHPFPM_PM_STATUS_PATH}" ]; then
+    sed -i -e "s|^;pm.status_path = /status|pm.status_path = ${PHPFPM_PM_STATUS_PATH}|" /usr/local/etc/php-fpm.d/www.conf
+fi
+
+if [ -n "${PHPFPM_PING_PATH}" ]; then
+    sed -i -e "s|^;ping.path = /ping|ping.path = ${PHPFPM_PING_PATH}|" /usr/local/etc/php-fpm.d/www.conf
+fi
+
+if [ -n "${PHPFPM_REQUEST_TERMINATE_TIMEOUT}" ]; then
+    sed -i -e "s|^;request_terminate_timeout = 0|request_terminate_timeout = ${PHPFPM_REQUEST_TERMINATE_TIMEOUT}|" /usr/local/etc/php-fpm.d/www.conf
+fi
+
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+    set -- php-fpm "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
最近は GitHub Actions などの CI/CD の環境でも PHP5.4, 5.5 のビルドが難しくなってきているため、可能であればこちらのイメージに置き換えたいです。